### PR TITLE
A very basic default Welcome config to test that it works

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,9 @@
+newIssueWelcomeComment: >
+  Thanks for opening your first issue here! Be sure to follow the issue template!
+
+newPRWelcomeComment: >
+  Thanks for opening this pull request! Please check out our contributing guidelines.
+
+firstPRMergeComment: >
+  Congrats on merging your first pull request! We here at behaviorbot are proud of you!
+


### PR DESCRIPTION
Probot Config (which might be included in Probot apps we use from GitHub Apps) seems to support reading config from our .github repository if not overridden in individual repositories. Provide an example to test that it works. I've enabled https://github.com/apps/welcome on the Wash repo.