### PR TITLE
[WIP] adding standard support policy

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -35,7 +35,7 @@ You'll even find many Puppet engineers participating in conversations there.
 Many Puppet modules in this namespace were created by individuals solving a specific problem.
 The Forge Modules team will maintain and correct issues with modules in our namespace, but
 does not offer specific support for most (see below for specific supported modules). As above,
-if you have a support contract, then the Support team will attempt best-effor assistance.
+if you have a support contract, then the Support team will attempt best-effort assistance.
 
 The [Puppet Community Slack](https://slack.puppet.com) is a great way to get peer-to-peer help
 from people using these modules. You'll also find that the Forge Modules team is often available

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,66 @@
+# Puppet Support Policies
+
+Puppet's GitHub namespace contains many repositories for a great variety of types of projects,
+each with different levels of support. This document isn't intended to be a definitive resource
+explaining each level. Instead, it will link to the full support policy for each. Please refer
+to our [support services page](https://puppet.com/support-services) for more information on
+professional services, training, or certification. You're also invited to participate in our
+[vibrant and engaging community](https://puppet.com/community).
+
+
+## Products with support contracts
+
+With your support contract for any of Puppet’s products, you are eligible for help from our
+team of expert support engineers. The support benefit includes access to new product releases,
+bug fixes, an authenticated support portal and knowledge base.
+[Learn more](https://puppet.com/support-services/customer-support).
+
+
+## Puppet maintained Open Source Projects
+
+Our Open Source projects have no explicit support policy. If you have a support contract and
+you're using an Open Source project along with your supported product, then you'll receive
+best-effort assistance if you make support requests.
+
+You are invited to file issues on the project, or to contribute pull requests correcting the
+problem you're running into. That process will vary depending on the project. If GitHub issues
+are not enabled, then you'll need to file tickets in the appropriate [JIRA project](https://tickets.puppet.com).
+
+The [Puppet Community Slack](https://slack.puppet.com) is a great way to get peer-to-peer help.
+You'll even find many Puppet engineers participating in conversations there.
+
+
+## Modules
+
+Many Puppet modules in this namespace were created by individuals solving a specific problem.
+The Forge Modules team will maintain and correct issues with modules in our namespace, but
+does not offer specific support for most (see below for specific supported modules). As above,
+if you have a support contract, then the Support team will attempt best-effor assistance.
+
+The [Puppet Community Slack](https://slack.puppet.com) is a great way to get peer-to-peer help
+from people using these modules. You'll also find that the Forge Modules team is often available
+for questions in the `#forge-modules` channel.
+
+
+### Supported Modules
+
+Puppet Forge modules are pretty great at making your life easier. Puppet Supported modules take
+it one step further, making sure common services are easy to set up, implement, and manage with
+Puppet Enterprise. See the [support policy](https://forge.puppet.com/supported) on the Forge.
+
+### Partner Supported Modules
+
+Support for these modules is provided by a Puppet partner. In some cases, this may require a
+support contract with the partner vendor.
+
+### Approved Modules
+
+With the new Puppet Approved program, finding the right module is even easier. Puppet Approved
+modules are recommended by Puppet for use with Puppet Enterprise and meet our expectations for
+quality and usability. [Learn more](https://forge.puppet.com/approved) on the Forge.
+
+
+## All other repositories
+
+Some repositories in this namespace are personal or department "pet projects". They have no
+support implied whatsoever, although the developers might offer their own support expectations.


### PR DESCRIPTION
This will add a default support policy to GitHub repositories. It shows when people file an issue.
https://help.github.com/en/articles/adding-support-resources-to-your-project

It's not meant to be an actual reference, more like a quick summary guide and links to the actual policy.