### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @puppetlabs/open-source-stewards 


### PR DESCRIPTION
This adds a CODEOWNERS file so that Open Source Stewards team gets
pinged whenever a PR is opened