### PR TITLE
Add synonym labels and lower-case versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Create a report to help us improve.
 title: ''
-labels: 'Bug'
+labels: Bug, bug
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/docs-change.md
+++ b/.github/ISSUE_TEMPLATE/docs-change.md
@@ -2,7 +2,7 @@
 name: Docs Change
 about: Suggest a change to our documentation.
 title: ''
-labels: 'Docs'
+labels: Docs, docs
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest a feature or improvement.
 title: ''
-labels: 'Feature'
+labels: Feature, feature, Enhancement, enhancement
 assignees: ''
 ---
 


### PR DESCRIPTION
New repositories get default lower-case labels 'bug', 'docs', and 'enhancement'. Enhancement and Feature are synonyms that are unlikely to both exist. Add alternatives to each template so whichever is present will be used.

Signed-off-by: Michael Smith <michael.smith@puppet.com>