### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 ------
-Thanks for your contribution! Note that all community contributors will be required to sign our Contributor License Agreement, unless you fall under the [Trivial Patch Exemption Policy](https://puppet.com/community/trivial-patch-exemption-policy). Please comment explaining why you do not need to sign the CLA if you believe it applies to your pull request. Directions for signing will be attached to your pull request shortly.
+Thanks for your contribution! Note that all community contributors will be required to sign our Contributor License Agreement, unless you fall under the [Trivial Patch Exemption Policy](https://puppet.com/community/trivial-patch-exemption-policy). If you believe it applies to your pull request, please comment explaining why you do not need to sign the CLA. Directions for signing will be attached to your pull request shortly.
 
 Please note that all contributions may be publicly recognized in release notes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+------
+Thanks for your contribution! Note that all community contributors will be required to sign our Contributor License Agreement, unless you fall under the [Trivial Patch Exemption Policy](https://puppet.com/community/trivial-patch-exemption-policy). Please comment explaining why you do not need to sign the CLA if you believe it applies to your pull request. Directions for signing will be attached to your pull request shortly.
+
+Please note that all contributions may be publicly recognized in release notes.


### PR DESCRIPTION
This PR template surfaces the trivial patch exemption immediately so that the wall-of-text CLA is hopefully less intrusive.

It also adds a notification that contributions may receive public recognition in release notes. With this change, Legal has signed off on us providing recognition and on IAC continuing to provide recognition.

Language is totally open for wordsmithing. The body of the commit will be prepended to this template, so behavior is not substantially changed. There is also the ability to add parameters to the template, I didn't think it was needed but if anyone else wants to tackle it, then go for it. https://docs.github.com/en/github/managing-your-work-on-github/about-automation-for-issues-and-pull-requests-with-query-parameters