### PR TITLE
Fix a typo and remove extra empty lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ respectively.
 
 By running tests in advance and by engaging with peer review for prospective
 changes, your contributions have a high probability of becoming long lived
-parts of the the project. After being merged, the code will run through a
+parts of the project. After being merged, the code will run through a
 series of testing pipelines on a large number of operating system
 environments. These pipelines can reveal incompatibilities that are difficult
 to detect in advance.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # .github
+
 Default community health files for the Puppet Labs org
 
 See below for more information.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -29,7 +29,6 @@ are not enabled, then you'll need to file tickets in the appropriate [JIRA proje
 The [Puppet Community Slack](https://slack.puppet.com) is a great way to get peer-to-peer help.
 You'll even find many Puppet engineers participating in conversations there.
 
-
 ## Modules
 
 Many Puppet modules in this namespace were created by individuals solving a specific problem.
@@ -40,7 +39,6 @@ Support team will attempt best-effort assistance.
 The [Puppet Community Slack](https://slack.puppet.com) is a great way to get peer-to-peer help
 from people using these modules. You'll also find that the Forge Modules team is often available
 for questions in the `#forge-modules` channel.
-
 
 ### Supported Modules
 
@@ -60,7 +58,6 @@ support contract with the partner vendor.
 With the new Puppet Approved program, finding the right module is even easier. Puppet Approved
 modules are recommended by Puppet for use with Puppet Enterprise and meet our expectations for
 quality and usability. [Learn more](https://forge.puppet.com/approved) on the Forge.
-
 
 ## All other repositories
 


### PR DESCRIPTION
There was an extra "the" in the contributing doc and extra spaces that were throwing markdown warnings.

Signed-off-by: Tim Smith <tsmith84@gmail.com>